### PR TITLE
Add Progress Bars for Downloading and Unzipping Datasets

### DIFF
--- a/emip_toolkit.py
+++ b/emip_toolkit.py
@@ -1728,5 +1728,4 @@ def download(dataset_name):
     print('Please cite this paper: ', citation)
 
     return './datasets/' + dataset_name
-    
-download('EMIP')
+  

--- a/emip_toolkit.py
+++ b/emip_toolkit.py
@@ -1700,6 +1700,7 @@ def download(dataset_name):
     """
 
     url, is_zipped, citation = data_dictionary[dataset_name]
+    target_path = './datasets/' + dataset_name
 
     # Check if dataset has already been downloaded
     if not check_downloaded(dataset_name):
@@ -1723,16 +1724,15 @@ def download(dataset_name):
         print('unzipping...')
 
         #extract all data
-        with zipfile.ZipFile('./datasets/' + dataset_name + '.zip', 'r') as data_zip:
-            # data_zip.extractall('./datasets/' + dataset_name)
+        with zipfile.ZipFile(target_path + '.zip', 'r') as data_zip:
 
             for member in tqdm(data_zip.infolist(), desc='Extracting '):
                 try:
-                    data_zip.extract(member, './datasets/' + dataset_name)
+                    data_zip.extract(member, target_path)
                 except zipfile.error as e:
                     pass
 
 
     print('Please cite this paper: ', citation)
 
-    return './datasets/' + dataset_name
+    return target_path

--- a/emip_toolkit.py
+++ b/emip_toolkit.py
@@ -18,6 +18,7 @@ from matplotlib import pyplot as plt
 from PIL import Image, ImageDraw, ImageEnhance, ImageFont
 import requests, zipfile
 from clint.textui import progress
+from tqdm import tqdm
 
 # Dictionary for datasets Key = dataset_name, Value = [url, is_zipped, citation]
 data_dictionary = {'EMIP' : ['https://osf.io/j6vt3/download', False, 'https://dl.acm.org/doi/abs/10.1145/3448018.3457425']}
@@ -1723,9 +1724,15 @@ def download(dataset_name):
 
         #extract all data
         with zipfile.ZipFile('./datasets/' + dataset_name + '.zip', 'r') as data_zip:
-            data_zip.extractall('./datasets/' + dataset_name)
+            # data_zip.extractall('./datasets/' + dataset_name)
+
+            for member in tqdm(data_zip.infolist(), desc='Extracting '):
+                try:
+                    data_zip.extract(member, './datasets/' + dataset_name)
+                except zipfile.error as e:
+                    pass
+
 
     print('Please cite this paper: ', citation)
 
     return './datasets/' + dataset_name
-  


### PR DESCRIPTION
#34 
Added progress bars for downloading and unzipping datasets in download(). 
  
Terminal output:  

Download
  
<img width="605" alt="download" src="https://user-images.githubusercontent.com/52256322/146606834-b169ad64-b55c-4288-996b-383f471a0b64.png">

Unzip
  
<img width="885" alt="unzip" src="https://user-images.githubusercontent.com/52256322/146606859-e8272f20-83d4-4589-b945-37f41787260c.png">

Complete 
  
<img width="885" alt="done" src="https://user-images.githubusercontent.com/52256322/146606883-649bda14-652d-4bbc-8bae-d941ed30c71e.png">
