### PR TITLE
Readme: Use youtube's preview picture as video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The use of eye tracking in the study of program comprehension in software engine
 
 [Read More...](https://www.researchgate.net/publication/350485560_EMIP_Toolkit_A_Python_Library_for_Customized_Post-processing_of_the_Eye_Movements_in_Programming_Dataset).
 
-[![Watch the video](https://img.youtube.com/vi/<wFdGyM6qUlE>/maxresdefault.jpg)](https://www.youtube.com/watch?v=wFdGyM6qUlE)
+[![Watch the video](https://imgur.com/IcowLr3.png)](https://www.youtube.com/watch?v=wFdGyM6qUlE)
 
 # Please Cite: 
 Naser Al Madi, Drew T. Guarnera, Bonita Sharif, and Jonathan I. Maletic.2021. EMIP Toolkit: A Python Library for Customized Post-processing of the Eye Movements in Programming Dataset. In ETRA ’21: 2021 Symposium on Eye Tracking Research and Applications (ETRA ’21 Short Papers), May25–27, 2021, Virtual Event, Germany. ACM, New York, NY, USA, 6 pages. https://doi.org/10.1145/3448018.3457425

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The use of eye tracking in the study of program comprehension in software engine
 
 [Read More...](https://www.researchgate.net/publication/350485560_EMIP_Toolkit_A_Python_Library_for_Customized_Post-processing_of_the_Eye_Movements_in_Programming_Dataset).
 
-[Watch Video](https://youtu.be/wFdGyM6qUlE)
+[![Watch the video](https://img.youtube.com/vi/<wFdGyM6qUlE>/maxresdefault.jpg)](https://www.youtube.com/watch?v=wFdGyM6qUlE)
 
 # Please Cite: 
 Naser Al Madi, Drew T. Guarnera, Bonita Sharif, and Jonathan I. Maletic.2021. EMIP Toolkit: A Python Library for Customized Post-processing of the Eye Movements in Programming Dataset. In ETRA ’21: 2021 Symposium on Eye Tracking Research and Applications (ETRA ’21 Short Papers), May25–27, 2021, Virtual Event, Germany. ACM, New York, NY, USA, 6 pages. https://doi.org/10.1145/3448018.3457425


### PR DESCRIPTION
Hi Prof. Al Madi, I am improving the README file. Regarding the video of the presentation, I came up with two ideas. One is to use youtube's preview picture as the video link, the other is to embed the video into the README file directly. In this pull request, I am using youtube's preview picture. The other one in another branch will be pushed soon.